### PR TITLE
корректное изменение пароля

### DIFF
--- a/src/components/AccModal.vue
+++ b/src/components/AccModal.vue
@@ -14,11 +14,14 @@ export default {
   emits: ['AccLogout'],
   data () {
     return {
-      showEditname: false,
       oldPassword: '',
       newPassword: '',
       confirmNewPassword: '',
-      showError: false,
+      invalidOldPassword: '',
+      showEditname: false,
+      newPassError: false,
+      emptyOldPass: false,
+      emptyNewPasses: false,
       showEditphone: false,
       showEditpassword: false
     }
@@ -60,17 +63,33 @@ export default {
     changeUserPassword () {
       const oldPassword = this.oldPassword
       const newPassword = this.newPassword
+      const isFieldNotEmptyAndRight = oldPassword && this.newPassword && this.confirmNewPassword && this.newPassword === this.confirmNewPassword
       const data = {
         old_password: oldPassword,
         new_password: newPassword
       }
-      if (oldPassword && this.newPassword === this.confirmNewPassword) {
-        this.$store.dispatch(AUTH_CHANGE_PASSWORD, data)
-        this.showEditpassword = false
-        this.showError = false
-      } else {
-        this.showError = true
+      if (isFieldNotEmptyAndRight) {
+        this.$store.dispatch(AUTH_CHANGE_PASSWORD, data).then(() => {
+          this.showEditpassword = false
+          this.oldPassword = ''
+          this.newPassword = ''
+          this.confirmNewPassword = ''
+        })
+
+        this.$store.dispatch(AUTH_CHANGE_PASSWORD, data).catch(err => {
+          this.invalidOldPassword = err.error
+          this.oldPassword = ''
+          this.confirmNewPassword = ''
+          this.showEditpassword = true
+          this.emptyOldPass = false
+        })
+      } else if (this.newPassword !== this.confirmNewPassword) {
+        this.newPassError = true
       }
+      // проверяем пустое поле старого пароля
+      oldPassword ? this.emptyOldPass = false : this.emptyOldPass = true
+      // проверяем пустые поля нового пароля
+      this.newPassword && this.confirmNewPassword ? this.emptyNewPasses = false : this.emptyNewPasses = true
     },
 
     changeUserPhone (phone) {
@@ -137,9 +156,9 @@ export default {
   >
     <div class="flex flex-col w-full">
       <div>
-        <p class="mb-[10px] mt-[10px]">
+        <!-- <p class="mb-[10px] mt-[10px]">
           Введите старый пароль
-        </p>
+        </p> -->
         <input
           v-model="oldPassword"
           type="text"
@@ -148,6 +167,18 @@ export default {
           class="bg-[#f4f5f7]/50 rounded-[6px] border border-[#4c4c4d] focus:border-[#ff9123] w-full px-[14px] py-[11px] text-[14px] leading-[16px] text-[#4c4c4d] font-roboto"
         >
       </div>
+      <p
+        v-if="invalidOldPassword === 'old_password invalid'"
+        class="text-red-500 text-xs mt-1 ml-1"
+      >
+        Корректно введите старый пароль
+      </p>
+      <p
+        v-if="emptyOldPass"
+        class="text-red-500 text-xs mt-1 ml-1"
+      >
+        Введите старый пароль
+      </p>
       <div>
         <p class="mb-[10px] mt-[10px]">
           Введите новый пароль
@@ -173,7 +204,13 @@ export default {
         >
       </div>
       <p
-        v-if="showError"
+        v-if="emptyNewPasses"
+        class="text-red-500 text-xs mt-1 ml-1"
+      >
+        Заполните все поля ввода нового пароля
+      </p>
+      <p
+        v-if="newPassError"
         class="text-red-500 text-xs mt-1 ml-1"
       >
         Пароли не совпадают

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -83,10 +83,12 @@ const actions = {
         })
     })
   },
-  [AUTH_CHANGE_PASSWORD]: ({ commit }, data) => {
-    console.log(data)
+  [AUTH_CHANGE_PASSWORD]: (
+    { commit },
+    data
+  ) => {
     return new Promise((resolve, reject) => {
-      commit(AUTH_CHANGE_PASSWORD)
+      // commit(AUTH_CHANGE_PASSWORD) unknown
       const url = process.env.VUE_APP_LEADERTASK_API + 'api/v1/users/password'
       axios({ url: url, data: data, method: 'PATCH' })
         .then((resp) => {
@@ -97,17 +99,18 @@ const actions = {
         })
         .catch((err) => {
           commit(AUTH_ERROR, err)
-          localStorage.removeItem('user-token')
-          notify(
-            {
-              group: 'api',
-              title: 'REST API Error, please make screenshot',
-              action: AUTH_CHANGE_PASSWORD,
-              text: err.response?.data ?? err
-            },
-            15000
-          )
-          reject(err)
+          reject(err.response.data)
+          if (err.response?.data?.error !== 'old_password invalid') {
+            notify(
+              {
+                group: 'api',
+                title: 'REST API Error, please make screenshot',
+                action: AUTH_CHANGE_PASSWORD,
+                text: err.response?.data ?? err
+              },
+              15000
+            )
+          }
         })
     })
   },


### PR DESCRIPTION
Форма больше не отправляется, если есть пустые поля. Больше не выкидывает на страницу логина при неправильном вводе старого пароля.