### PR TITLE
Билд 26 июля (залив пул реквестов) (#242)

### DIFF
--- a/src/components/AsideMenu.vue
+++ b/src/components/AsideMenu.vue
@@ -127,6 +127,9 @@ export default {
       if (this.isPropertiesMobileExpanded) {
         this.$store.dispatch('asidePropertiesToggle', false)
       }
+      if (this.isAsideMobileExpanded) {
+        this.$store.dispatch('asideMobileToggle', false)
+      }
 
       // do it now
       if (item.uid === '2cf6b167-6506-4b05-bc34-70a8d88e3b25') {
@@ -224,6 +227,9 @@ export default {
       if (this.isPropertiesMobileExpanded) {
         this.$store.dispatch('asidePropertiesToggle', false)
       }
+      if (this.isAsideMobileExpanded) {
+        this.$store.dispatch('asideMobileToggle', false)
+      }
 
       this.$store.commit('basic', { key: 'mainSectionState', value: 'greed' })
       const path = 'new_private_boards'
@@ -260,6 +266,9 @@ export default {
     goToProject (project) {
       if (this.isPropertiesMobileExpanded) {
         this.$store.dispatch('asidePropertiesToggle', false)
+      }
+      if (this.isAsideMobileExpanded) {
+        this.$store.dispatch('asideMobileToggle', false)
       }
 
       this.$store.commit('basic', { key: 'mainSectionState', value: 'greed' })

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -211,6 +211,8 @@
               :animation="100"
               :disabled="!board || board.type_access === 0"
               :move="checkMoveDragCard"
+              :scroll-sensitivity="250"
+              :force-fallback="true"
               @start="startDragCard"
               @end="endDragCard"
               @change="changeDragCard"
@@ -680,9 +682,8 @@ export default {
       const fromColumn = this.storeCards.find(
         (column) => column.UID === fromColumnId
       )
-      // const cardId = start.item.dataset.cardId
       const card = fromColumn?.cards[start.oldIndex] || null
-      //
+
       this.dragCardParam.move.column = fromColumn
       this.dragCardParam.move.card = card
     },

--- a/src/components/Doitnow.vue
+++ b/src/components/Doitnow.vue
@@ -111,8 +111,7 @@ export default {
         this.unreadTasks.length +
         this.overdueTasks.length +
         this.readyTasks.length +
-        this.todayTasks.length +
-        this.openedTasks.length
+        this.todayTasks.length
       )
     },
     firstTask () {
@@ -127,9 +126,6 @@ export default {
       }
       if (this.todayTasks.length) {
         return this.todayTasks[0]
-      }
-      if (this.openedTasks.length) {
-        return this.openedTasks[0]
       }
       return null
     },

--- a/src/components/Reglaments/ReglamentContent.vue
+++ b/src/components/Reglaments/ReglamentContent.vue
@@ -549,5 +549,3 @@ export default {
   }
 }
 </script>
-<style scoped>
-</style>

--- a/src/components/Reglaments/ReglamentPropsUser.vue
+++ b/src/components/Reglaments/ReglamentPropsUser.vue
@@ -4,7 +4,7 @@
       :src="employees[userUid]?.fotolink"
       class="flex-none border border-[#7e7e80] rounded-[4px] w-[20px] h-[20px] mr-[7px]"
     >
-    <span class="grow font-roboto text-[13px] leading-[20px] font-medium text-[#4c4c4d] mr-[7px]">{{ employees[userUid]?.name ?? '???' }}</span>
+    <span class="grow font-roboto text-[13px] leading-[20px] font-medium text-[#4c4c4d] mr-[7px]">{{ employees[userUid]?.name || employees[userUid]?.email }}</span>
   </div>
 </template>
 <script>

--- a/src/components/TasksListNew.vue
+++ b/src/components/TasksListNew.vue
@@ -852,6 +852,9 @@ export default {
       this.$store.commit(TASK.COPY_TASK, copiedTask)
     },
     nodeSelected (arg) {
+      if (arg.info.name === '') {
+        this.editTaskName(arg.info.uid)
+      }
       this.lastSelectedTask = arg.info
       if (!this.isPropertiesMobileExpanded && arg.info.name) {
         this.$store.dispatch('asidePropertiesToggle', true)

--- a/src/css/_app.css
+++ b/src/css/_app.css
@@ -12,7 +12,7 @@ html
   font-family: 'Roboto'
 }
 #app {
-  @apply w-screen h-full transition-position lg:w-auto;
+  @apply w-screen h-full transition-position xl:w-auto;
 }
 
 .dropdown {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -80,7 +80,7 @@ export default createStore({
   actions: {
     asideMobileToggle ({ commit, state }, payload = null) {
       const isShow = payload !== null ? payload : !state.isAsideMobileExpanded
-      document.getElementById('app').classList[isShow ? 'add' : 'remove']('ml-80', 'lg:ml-0')
+      document.getElementById('app').classList[isShow ? 'add' : 'remove']('ml-80', 'xl:ml-0')
       document.documentElement.classList[isShow ? 'add' : 'remove']('m-clipped')
 
       commit('basic', {


### PR DESCRIPTION
* список сотрудников в попменю редакторов в регламентах

* добавление сотруддника в editors

* Заменил lg property на xl, чтобы небыло расхождений по верстке на разных экранах (т.к отказались от промежуточного lg экрана)

* добавлены лимиты в регламенты

* Закрытие левого AsideMenu при клике на какой-либо пункт меню

* не отображать вопрос (если нет правильного ответа)/кнопку (если в регламенте нет правильных ответов

* владелец лицензии может удалить любой регламент

* Убрал из очереди задачи, за которыми не следим

* плавный скролл переноса карточек

добавил чувствительность скролла и теперь присутсвует скролл при подносе карточки вверх таблицы и вниз

* поправил return

* корректная проверка на владельца лицензии

* давать доступ на редактирование регламента сотрудникам

* fix conflicts

* В свойствах сотрудника отображать всё регламенты

* пустое имя в прошедших регламент

теперь отображение почты если нет имени

* Фикс: при нажатии на новую созданную субтаску без имени - имя теперь можно изменить

* отображение поля редакторы и фикс скроллов в попменю

* логика отображения выбранных сотрудников в попменю редакторов регламентов

* Добавил консоль на выбранную задачу

Убрал лишние консольки

* правка галочки в попменю

* скролл в конец заметки

* Кнопка "Передать инспектору" в свойствах задачи

* удаление комментариев

неиспользуемая переменная, комментирование строки для пробела

* Рефакторинг

Теперь без запроса получение пройденных регламентов

* автор регламента не может добавить себя в редакторы

Co-authored-by: kakeoff <jasonsuper04@gmail.com>
Co-authored-by: Samarkin danya0 Danil <samarkin.danil@yandex.ru>
Co-authored-by: Bukharin Maxim <jojojopa@icloud.com>
Co-authored-by: danya0 <50441905+danya0@users.noreply.github.com>
Co-authored-by: yzk-jssc <egonik1337@gmail.com>
Co-authored-by: Panteleev Egor <101832333+kakeoff@users.noreply.github.com>
Co-authored-by: Dmitry <gashilovdmitry@yandex.ru>