### PR TITLE
Фикс проблемы с заметками (#330)

### DIFF
--- a/src/components/Doitnow/DoitnowTask.vue
+++ b/src/components/Doitnow/DoitnowTask.vue
@@ -201,31 +201,33 @@
         :task="task"
       />
       <div
-        class="flex flex-col max-w-1/2 border-t mt-2 pt-2"
+        class="max-w-1/2 border-t mt-2 pt-2"
         :class="task.uid_marker !== '00000000-0000-0000-0000-000000000000' ? 'bg-white p-1 mt-1 rounded-lg' : ''"
       >
-        <!-- input -->
-        <TaskPropsInputForm
-          :task="task"
-          @readTask="readTask"
-        />
-        <!-- chat -->
-        <TaskPropsChatMessages
-          v-if="taskMessages?.length"
-          id="content"
-          class="mt-3"
-          :task="task"
-          :task-messages="taskMessages"
-          :current-user-uid="user.current_user_uid"
-          :show-all-messages="true"
-          :show-only-files="showOnlyFiles"
-          @answerMessage="answerMessage"
-          @sendTaskMsg="sendTaskMsg"
-          @onPasteEvent="onPasteEvent"
-          @deleteFiles="deleteFiles"
-          @deleteTaskMsg="deleteTaskMsg"
-          @readTask="readTask"
-        />
+        <div class="mx-auto max-w-[540px]">
+          <!-- input -->
+          <TaskPropsInputForm
+            :task="task"
+            @readTask="readTask"
+          />
+          <!-- chat -->
+          <TaskPropsChatMessages
+            v-if="taskMessages?.length"
+            id="content"
+            class="mt-3"
+            :task="task"
+            :task-messages="taskMessages"
+            :current-user-uid="user.current_user_uid"
+            :show-all-messages="true"
+            :show-only-files="showOnlyFiles"
+            @answerMessage="answerMessage"
+            @sendTaskMsg="sendTaskMsg"
+            @onPasteEvent="onPasteEvent"
+            @deleteFiles="deleteFiles"
+            @deleteTaskMsg="deleteTaskMsg"
+            @readTask="readTask"
+          />
+        </div>
       </div>
     </div>
     <!-- accept/redo/decline -->

--- a/src/components/TaskProperties/TaskPropsInputForm.vue
+++ b/src/components/TaskProperties/TaskPropsInputForm.vue
@@ -4,14 +4,12 @@
     src="/ajaxloader.gif"
   >
   <div class="w-full mt-[40px]">
-    <div class="mx-auto max-w-[520px]">
-      <card-message-input
-        v-model="taskMsg"
-        :can-add-files="true"
-        @createCardMessage="sendTaskMsg"
-        @createCardFile="createTaskFile($event)"
-      />
-    </div>
+    <card-message-input
+      v-model="taskMsg"
+      :can-add-files="true"
+      @createCardMessage="sendTaskMsg"
+      @createCardFile="createTaskFile($event)"
+    />
   </div>
 </template>
 <script>

--- a/src/components/properties/CardProperties.vue
+++ b/src/components/properties/CardProperties.vue
@@ -79,7 +79,7 @@
     </div>
 
     <TaskPropsCommentEditor
-      v-if="canEditComment || selectedCard?.comment.length > 0"
+      v-if="canEdit || selectedCard?.comment.length > 0"
       class="mt-3 h-32 break-words"
       :comment="selectedCard?.comment"
       :can-edit="canEdit"


### PR DESCRIPTION
* список сотрудников в попменю редакторов в регламентах

* добавление сотруддника в editors

* Заменил lg property на xl, чтобы небыло расхождений по верстке на разных экранах (т.к отказались от промежуточного lg экрана)

* добавлены лимиты в регламенты

* Закрытие левого AsideMenu при клике на какой-либо пункт меню

* не отображать вопрос (если нет правильного ответа)/кнопку (если в регламенте нет правильных ответов

* владелец лицензии может удалить любой регламент

* Убрал из очереди задачи, за которыми не следим

* плавный скролл переноса карточек

добавил чувствительность скролла и теперь присутсвует скролл при подносе карточки вверх таблицы и вниз

* поправил return

* корректная проверка на владельца лицензии

* давать доступ на редактирование регламента сотрудникам

* fix conflicts

* В свойствах сотрудника отображать всё регламенты

* пустое имя в прошедших регламент

теперь отображение почты если нет имени

* Фикс: при нажатии на новую созданную субтаску без имени - имя теперь можно изменить

* отображение поля редакторы и фикс скроллов в попменю

* логика отображения выбранных сотрудников в попменю редакторов регламентов

* Добавил консоль на выбранную задачу

Убрал лишние консольки

* правка галочки в попменю

* скролл в конец заметки

* Кнопка "Передать инспектору" в свойствах задачи

* удаление комментариев

неиспользуемая переменная, комментирование строки для пробела

* Рефакторинг

Теперь без запроса получение пройденных регламентов

* автор регламента не может добавить себя в редакторы

* замени массив editors на поле editors в регламентах

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* ошибка создания регламента

* рабочее рендактирование рпегламента

* переделал логику доступа редакторов к редактированию регламента

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты(переделал)

* фикс ошибки unknown mutation type при выходе из аккаунта

* Update NavBarButtonsRight.vue

Поправил краш

* Фикс бага с пустыми и ломаными документами в чате задачи. Ссылка теперь приходит корректно и файл скачивается полностью

* редактор не может добавлять редакторов

* убрал ошибку undefined reading greedpath при входе в аккаунт

* отображение почты если указано имя

в карточках в колонках, в ответственных, в очереди

* перенос логики в store

* фикс селекта ответов

* реактивная очистка сотрудников и изменение условий проверки

* Update BoardCard.vue

* фикс svg'шки почты на странице логина(ошибку)

* исправление ошибки svg стрелочки на странице логина

* исправление стрелочки назад

* рефакторинг InspectorNotification.vue

* удаление закомментированного кода

удаление кода, который висит закомментированным месяцами и не используется

* рефакторинг moviepreloader.vue

* Рефактор FileMessage.vue в options API

* websync создание регламентов

* закомментировал изменения по вебсинку

* рабочий websync регламентов

* Update ModalBox.vue

Добавил установить еще две кнопки accept - активная кнопка, decline - пассивная (по цвету различные) и эмитят соответствующие события по нажатию

* Update navigator.js

Инвайты теперь сервер присылает по другому - этот кода не рабочий - убран

* websync регламентов

* Update BoardCard.vue

* Update CardResponsibleUser.vue

* добавил getter в navbar.js 'lastNavStackElement'

* Home.vue рефактор

* логика для websync reglament questions в отдельном файле

* Исправлено сообщение от инспектора

Не отображалось имя заказчика в сообщении о том что просрочена задача

* Update CardResponsibleUser.vue

* Фикс бага с бесконечным скелетоном AsideMenu при нажатии на Показать/Скрыть завершенные задачи

* Не перебрасывается последняя карточка из неразобранного

* Отображается неразобранное при драг-н-дропе карточек

* Рефакторинг

Убрал консоль

* Рефакторинг

Убрал фото если нет, имя пользователя если нет такого вопросами

* Не верно отрабатывает выбор карточки

Бывает не кликается (из-за того что включается драг-н-дроп или жмем в область вокруг меню)

* устанвил delay на 80 мс

* Фикс бага с неотображением вкладки сегодня после перезагрузки на ней (при рефакторе убрал ключ 'value' который был необходим)

* убрал лишнюю проверку в reglaments questions websync

* Добавил необхоидмые value ключи

* Убрал обращение к NAVIGATOR_REQUEST в методе PATCH_SETTING

* логика для websync reglaemnt answers в отдельном файле

* Убрал несуществующую функцию

* ДОбавил фильтр "Нет ответственного"

* добавил мутацию обновления вопроса

* привязал логику добавления, удаления, обновления вопросов и ответов в websync

* пофиксил баг, когда нельзя было проставить редакторов в только что созданном регламенте

* пофиксил баг, когда не удалялся регламент из навигатора

* Поправлен драг-н-дроп карточек

Запрещаем драг-н-дроп если отфильтровали (иначе не те карточки кидает)

* исправил ошибку createReglamentAnswer is not a function

* Исправлено не обновляется регламент по кнопке сохранить

* пофиксил баг с шивронами, когда драгаешь задачу, иногда шиврон не появлялся

* добавил возможность создавать редактировать и проходить регламенты при триале

* Вывод отдела в свойствах регламента

* Установка отдела у регламента

* Поменял формулировку общих регламентов

* теперь при создании вопроса, сразу же создается пустой ответ и на сервере

* Фикс бага: не обновлялся раздел 'Поручения' при удалении последней задачи в 'Поручено мне'

* Разбивка регламентов по отделам

* Только доступные регламенты

Можно добавлять регламенты сразу в свой отдел, отображаются только общие регламенты и регламенты из своего отдела, админы могу посмотреть все регламенты

* Убрал возможность установить не свой отдел у регламента

* рефакторинг(перенос всех popmenu из modals в common

* save changes

* В свойствах сотрудника регламенты отдела

* изменение визуала в очереди

* Убрал задержку при драг-н-дропе

* Выделять карточку при "быстром" дропе

* сделал правнее анимацию драга карточек, поставил больше scroll sensitivity, и добавил fall-backtolerance=1

* websynk колонок в досках

* яндекс метрика на очереди

* Убарл горизонтальный скролл основного контента при выдвинутом AsideMenu на lg экранах

* Рефактор store/boards. Вписал новые мутации в экшны

* Релиз "Регламенты" (#291) (#292)

* Фикс: больше не пропадает подзадача при клике на неё, только при потере фокуса

* Update Reglaments.vue

Добавлено разделение на свои и чужие регламенты

* баг с исчезновением отступов при закрытии свойств на esc

* reglament debug

* удаление иконки

удаление иконки скрытия для бурегера (не нужной) на средних экранах

* На пройденных регламентах галочка

* Update Reglaments.vue

Убрал консоль

* добавил мутацию update reglament и привязал ее к кнопке пройти тест

* правки по дизайну в регламентах

* правки по дизайну в регламентах

* прохождение регламента начинается сверху страницы

перемещение скролла вверх страницы при старте регламента

* правки по вопросам и ответам в регламентах

* запрос на удаление ответов пользователей/настройка в режиме редактировании

* теперь после обновления страницы лт не ломается

* Теперь подзадачи пропадают, в случае если мы отказываемся от доступа к ней (до этого удалялись только после перезагрузки)

* добавил отображение пройденных регламентов в свойствах сотрудника

* рефакторинг 2 компонентов( комментарий)

удаление закоменнтированного кода и поправление кода с помощью eslint

* кликабельная ссылка в описании

* Регламенты редактирование и отображение

Регламент - отображение и редактирование, редактирование только при создании + рефакторинг

* изначальное значение для бюджета

в бюджете, если нет прошлого значения пустая строка, если есть показывает указанное в бюджете

* Цвета сразу добавляются в 'color', чтобы плашка красилась без перезагрузки страницы

* рефакторинг employee.vue

* поправил отображение неправильных ответов

* удаление неиспользуемого закоменнтированного кода

* логика для селекта одного ответа

* добавил отображение инспектруемых задач в списке

* рефакторинг ControlIcon.vue

* Билд 22 Июля (#226)

* Update README.md

Коммиты пишем русским языком

* Update CardName.vue

Не верно отображается заголовок у карточки

* Кнопка пройти тесты подгружается быстрее/при создании регламента сразу переходим в режим редактирования

* убрана функция покинуть регламент

* фикс бага если нет тарифа альфа, то в настройках аккаунта были ограничены все разделы, хотя должен быть ограничен только раздел кармы

* Update AsideMenu.vue

Не загружается приложение при первом входе

* вернул изменения по смене названия задачи

* Показывается количество правильных ответов в вопросе

* Пропадает поле название у карточки если стереть всё в хроме

* вынес логику инициализации navStack в отдельную функцию в Home.vue

* Update README.md

Дополнил про коммиты

* Update DoitnowTask.vue

Рефакторинг

* изменения в компонентах регламентов и добавление иконки регламентам

* небольшой рефакторинг по DRY в Home.vue

* Отображение вопросов, на которые мы дали неверный ответ

* При создании вопроса в регламенте нужно сразу создавать вместе с ним один ответ

* фикс багов (#214)

* фикс бага если нет тарифа альфа, то в настройках аккаунта были ограничены все разделы, хотя должен быть ограничен только раздел кармы

* вернул изменения по смене названия задачи

* изменения в компонентах регламентов и добавление иконки регламентам

* Task day fix (#217)

* набросок(без редиректа на регламент)

* реализация перехода по ссылке

* исправление конфликтов

Co-authored-by: Dmitry <gashilovdmitry@yandex.ru>

* свойства перенесены на лицевую сторону регламентов

* свойства регламентов перенесены на лицевую часть регламента

* Update TaskProperties.vue

Фикс: Стирается вводимое сейчас сообщение при обновлении задачи через вебсинк (сделал проверку смены задачи по uid)

* добавил скелетон для меню левого меню навигации

* убрал script из компонента скелетона

* добавил поле user_uid к запросу регламентов (для флага is_passed у самого регламента при получении списка)

* Баг фиксы (#218)

* Добавил в websynk updateTask удаление задачи в случае если удалили дату; и перенос задачи на другую дату

* Добавил в websynk updateTask удаление задачи в случае если удалили дату; и перенос задачи на другую дату #2

* User-Frendly сообщение, при нажатии на: 'Цвет', 'Проект', 'Метки' - в случае если они пустые

* Удалил add dot из вебсинка

* Правки по визуалу в регламентах. Убраны дубликаты сотрудников, изменены подложки у сообщений

* фикс по удалению регламента

* changes

* фикс кнопка редактировать видна при прохождении теста, кнопка пройти тест видна после прохождения теста

* fixing bugs (#219)

* фикс бага если нет тарифа альфа, то в настройках аккаунта были ограничены все разделы, хотя должен быть ограничен только раздел кармы

* вернул изменения по смене названия задачи

* изменения в компонентах регламентов и добавление иконки регламентам

* добавил скелетон для меню левого меню навигации

* убрал script из компонента скелетона

* фикс кнопка редактировать видна при прохождении теста, кнопка пройти тест видна после прохождения теста

* Update FileMessage.vue

Исправлено дублирование картинок

* Добавил scoped к стилям, больше нет багов с subtask и чек-листом (#220)

* Update FileMessage.vue

Вставил ограничение на 10 попыток скачать файл

* Баг с шириной плашек

Не верно отображаются плашки по ширине - уходят за экран если их отобразить списком

* Закрытие PropertiesRightAside, если оно открыто - при переходе на избранную вкладку

* левая меню на средних экранах

теперь левая менюшка "катается" так же как на мобилках

* Фикс: больше не пропадает подзадача при клике на неё, только при потере фокуса

* Update Reglaments.vue

Добавлено разделение на свои и чужие регламенты

* баг с исчезновением отступов при закрытии свойств на esc

* reglament debug

* удаление иконки

удаление иконки скрытия для бурегера (не нужной) на средних экранах

* На пройденных регламентах галочка

* Update Reglaments.vue

Убрал консоль

* добавил мутацию update reglament и привязал ее к кнопке пройти тест

* правки по дизайну в регламентах

* правки по дизайну в регламентах

* прохождение регламента начинается сверху страницы

перемещение скролла вверх страницы при старте регламента

* правки по вопросам и ответам в регламентах

* запрос на удаление ответов пользователей/настройка в режиме редактировании

* теперь после обновления страницы лт не ломается

* Теперь подзадачи пропадают, в случае если мы отказываемся от доступа к ней (до этого удалялись только после перезагрузки)

* добавил отображение пройденных регламентов в свойствах сотрудника

* рефакторинг 2 компонентов( комментарий)

удаление закоменнтированного кода и поправление кода с помощью eslint

* кликабельная ссылка в описании

* Регламенты редактирование и отображение

Регламент - отображение и редактирование, редактирование только при создании + рефакторинг

* изначальное значение для бюджета

в бюджете, если нет прошлого значения пустая строка, если есть показывает указанное в бюджете

* Цвета сразу добавляются в 'color', чтобы плашка красилась без перезагрузки страницы

* рефакторинг employee.vue

* поправил отображение неправильных ответов

* удаление неиспользуемого закоменнтированного кода

* логика для селекта одного ответа

* добавил отображение инспектруемых задач в списке

* рефакторинг ControlIcon.vue

Co-authored-by: Maslov Dmitry <63534992+devmaslove@users.noreply.github.com>
Co-authored-by: Bukharin Maxim <jojojopa@icloud.com>
Co-authored-by: kakeoff <jasonsuper04@gmail.com>
Co-authored-by: Panteleev Egor <101832333+kakeoff@users.noreply.github.com>
Co-authored-by: Egor <egonik1337@gmail.com>
Co-authored-by: danya0 <50441905+danya0@users.noreply.github.com>
Co-authored-by: Samarkin danya0 Danil <samarkin.danil@yandex.ru>

* фикс ошибок, после фикса конфликтов

* убарл коммент

* Выправил коммиты

* запрет на перенос строки в вопросах регламента

* логика с отображение неправильных вопросов/выравнивание текста

* переделана логика для отображения неправильных вопросов

* поправил ошибку с иконкой

* поправил размер иконки

* Отображене избранных вкладок под главным списком меню

* Убарл неиспользуемые передаваемые пропсы и эмиты в AsideMenuList

* добавил отправку инфо организации при инициализации websocket inspector

* Update main.js

Поправил краш при анализе ошибки от сервера

* добавил отправку токена при инициализации websocket inspector

* загрузка регламентов отложена

* вернул старую логику

* фикс некорректное добавление задачи с меткой

* логика для показа неправильных вопросов

* Update Home.vue

Поправил загрузку навигатора - показываем что грузимся до запроса регламентов и запускаем загрузку навигатора не зависимо от того удалось ли загрузить регламенты

* развыделять ответы, после того как тест был пройден

* Update NavBarButtonsReglament.vue

Поправил краш

* добавит типы для websync регламентов

* добавление редакторов в регламенты(не доделано)

* убрал консол лог

* добавил логику парсинга websync при получении сообщения из websocket inspector

* список сотрудников в попменю редакторов в регламентах

* добавление сотруддника в editors

* Заменил lg property на xl, чтобы небыло расхождений по верстке на разных экранах (т.к отказались от промежуточного lg экрана)

* добавлены лимиты в регламенты

* Закрытие левого AsideMenu при клике на какой-либо пункт меню

* не отображать вопрос (если нет правильного ответа)/кнопку (если в регламенте нет правильных ответов

* владелец лицензии может удалить любой регламент

* Убрал из очереди задачи, за которыми не следим

* плавный скролл переноса карточек

добавил чувствительность скролла и теперь присутсвует скролл при подносе карточки вверх таблицы и вниз

* поправил return

* корректная проверка на владельца лицензии

* давать доступ на редактирование регламента сотрудникам

* fix conflicts

* В свойствах сотрудника отображать всё регламенты

* пустое имя в прошедших регламент

теперь отображение почты если нет имени

* Фикс: при нажатии на новую созданную субтаску без имени - имя теперь можно изменить

* отображение поля редакторы и фикс скроллов в попменю

* логика отображения выбранных сотрудников в попменю редакторов регламентов

* Добавил консоль на выбранную задачу

Убрал лишние консольки

* правка галочки в попменю

* скролл в конец заметки

* Кнопка "Передать инспектору" в свойствах задачи

* удаление комментариев

неиспользуемая переменная, комментирование строки для пробела

* Рефакторинг

Теперь без запроса получение пройденных регламентов

* автор регламента не может добавить себя в редакторы

* Билд 26 июля (#240)

* список сотрудников в попменю редакторов в регламентах

* добавление сотруддника в editors

* добавлены лимиты в регламенты

* не отображать вопрос (если нет правильного ответа)/кнопку (если в регламенте нет правильных ответов

* владелец лицензии может удалить любой регламент

* поправил return

* корректная проверка на владельца лицензии

* давать доступ на редактирование регламента сотрудникам

* fix conflicts

* В свойствах сотрудника отображать всё регламенты

* отображение поля редакторы и фикс скроллов в попменю

* логика отображения выбранных сотрудников в попменю редакторов регламентов

* Добавил консоль на выбранную задачу

Убрал лишние консольки

* правка галочки в попменю

* скролл в конец заметки

* Кнопка "Передать инспектору" в свойствах задачи

* Рефакторинг

Теперь без запроса получение пройденных регламентов

* автор регламента не может добавить себя в редакторы

Co-authored-by: kakeoff <jasonsuper04@gmail.com>
Co-authored-by: Bukharin Maxim <jojojopa@icloud.com>
Co-authored-by: Panteleev Egor <101832333+kakeoff@users.noreply.github.com>
Co-authored-by: Maslov Dmitry <63534992+devmaslove@users.noreply.github.com>

* Билд 26 июля (залив пул реквестов) (#242)

* список сотрудников в попменю редакторов в регламентах

* добавление сотруддника в editors

* Заменил lg property на xl, чтобы небыло расхождений по верстке на разных экранах (т.к отказались от промежуточного lg экрана)

* добавлены лимиты в регламенты

* Закрытие левого AsideMenu при клике на какой-либо пункт меню

* не отображать вопрос (если нет правильного ответа)/кнопку (если в регламенте нет правильных ответов

* владелец лицензии может удалить любой регламент

* Убрал из очереди задачи, за которыми не следим

* плавный скролл переноса карточек

добавил чувствительность скролла и теперь присутсвует скролл при подносе карточки вверх таблицы и вниз

* поправил return

* корректная проверка на владельца лицензии

* давать доступ на редактирование регламента сотрудникам

* fix conflicts

* В свойствах сотрудника отображать всё регламенты

* пустое имя в прошедших регламент

теперь отображение почты если нет имени

* Фикс: при нажатии на новую созданную субтаску без имени - имя теперь можно изменить

* отображение поля редакторы и фикс скроллов в попменю

* логика отображения выбранных сотрудников в попменю редакторов регламентов

* Добавил консоль на выбранную задачу

Убрал лишние консольки

* правка галочки в попменю

* скролл в конец заметки

* Кнопка "Передать инспектору" в свойствах задачи

* удаление комментариев

неиспользуемая переменная, комментирование строки для пробела

* Рефакторинг

Теперь без запроса получение пройденных регламентов

* автор регламента не может добавить себя в редакторы

Co-authored-by: kakeoff <jasonsuper04@gmail.com>
Co-authored-by: Samarkin danya0 Danil <samarkin.danil@yandex.ru>
Co-authored-by: Bukharin Maxim <jojojopa@icloud.com>
Co-authored-by: danya0 <50441905+danya0@users.noreply.github.com>
Co-authored-by: yzk-jssc <egonik1337@gmail.com>
Co-authored-by: Panteleev Egor <101832333+kakeoff@users.noreply.github.com>
Co-authored-by: Dmitry <gashilovdmitry@yandex.ru>

* замени массив editors на поле editors в регламентах

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* ошибка создания регламента

* рабочее рендактирование рпегламента

* переделал логику доступа редакторов к редактированию регламента

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты(переделал)

* фикс ошибки unknown mutation type при выходе из аккаунта

* Update NavBarButtonsRight.vue

Поправил краш

* Фикс бага с пустыми и ломаными документами в чате задачи. Ссылка теперь приходит корректно и файл скачивается полностью

* редактор не может добавлять редакторов

* убрал ошибку undefined reading greedpath при входе в аккаунт

* отображение почты если указано имя

в карточках в колонках, в ответственных, в очереди

* перенос логики в store

* фикс селекта ответов

* реактивная очистка сотрудников и изменение условий проверки

* Update BoardCard.vue

* фикс svg'шки почты на странице логина(ошибку)

* исправление ошибки svg стрелочки на странице логина

* исправление стрелочки назад

* рефакторинг InspectorNotification.vue

* удаление закомментированного кода

удаление кода, который висит закомментированным месяцами и не используется

* рефакторинг moviepreloader.vue

* Рефактор FileMessage.vue в options API

* websync создание регламентов

* закомментировал изменения по вебсинку

* рабочий websync регламентов

* Update ModalBox.vue

Добавил установить еще две кнопки accept - активная кнопка, decline - пассивная (по цвету различные) и эмитят соответствующие события по нажатию

* Update navigator.js

Инвайты теперь сервер присылает по другому - этот кода не рабочий - убран

* websync регламентов

* Билд 27 июля (#248)

* список сотрудников в попменю редакторов в регламентах

* добавление сотруддника в editors

* Заменил lg property на xl, чтобы небыло расхождений по верстке на разных экранах (т.к отказались от промежуточного lg экрана)

* добавлены лимиты в регламенты

* Закрытие левого AsideMenu при клике на какой-либо пункт меню

* не отображать вопрос (если нет правильного ответа)/кнопку (если в регламенте нет правильных ответов

* владелец лицензии может удалить любой регламент

* Убрал из очереди задачи, за которыми не следим

* плавный скролл переноса карточек

добавил чувствительность скролла и теперь присутсвует скролл при подносе карточки вверх таблицы и вниз

* поправил return

* корректная проверка на владельца лицензии

* давать доступ на редактирование регламента сотрудникам

* fix conflicts

* В свойствах сотрудника отображать всё регламенты

* пустое имя в прошедших регламент

теперь отображение почты если нет имени

* Фикс: при нажатии на новую созданную субтаску без имени - имя теперь можно изменить

* отображение поля редакторы и фикс скроллов в попменю

* логика отображения выбранных сотрудников в попменю редакторов регламентов

* Добавил консоль на выбранную задачу

Убрал лишние консольки

* правка галочки в попменю

* скролл в конец заметки

* Кнопка "Передать инспектору" в свойствах задачи

* удаление комментариев

неиспользуемая переменная, комментирование строки для пробела

* Рефакторинг

Теперь без запроса получение пройденных регламентов

* автор регламента не может добавить себя в редакторы

* замени массив editors на поле editors в регламентах

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* ошибка создания регламента

* рабочее рендактирование рпегламента

* переделал логику доступа редакторов к редактированию регламента

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты(переделал)

* фикс ошибки unknown mutation type при выходе из аккаунта

* Update NavBarButtonsRight.vue

Поправил краш

* редактор не может добавлять редакторов

* убрал ошибку undefined reading greedpath при входе в аккаунт

* перенос логики в store

* фикс селекта ответов

* реактивная очистка сотрудников и изменение условий проверки

* рефакторинг InspectorNotification.vue

* рефакторинг moviepreloader.vue

* websync создание регламентов

* закомментировал изменения по вебсинку

* рабочий websync регламентов

* Update ModalBox.vue

Добавил установить еще две кнопки accept - активная кнопка, decline - пассивная (по цвету различные) и эмитят соответствующие события по нажатию

* Update navigator.js

Инвайты теперь сервер присылает по другому - этот кода не рабочий - убран

* websync регламентов

Co-authored-by: kakeoff <jasonsuper04@gmail.com>
Co-authored-by: Samarkin danya0 Danil <samarkin.danil@yandex.ru>
Co-authored-by: Bukharin Maxim <jojojopa@icloud.com>
Co-authored-by: danya0 <50441905+danya0@users.noreply.github.com>
Co-authored-by: yzk-jssc <egonik1337@gmail.com>
Co-authored-by: Panteleev Egor <101832333+kakeoff@users.noreply.github.com>
Co-authored-by: Maslov Dmitry <63534992+devmaslove@users.noreply.github.com>

* Update BoardCard.vue

* Update CardResponsibleUser.vue

* добавил getter в navbar.js 'lastNavStackElement'

* Home.vue рефактор

* логика для websync reglament questions в отдельном файле

* Исправлено сообщение от инспектора

Не отображалось имя заказчика в сообщении о том что просрочена задача

* Update CardResponsibleUser.vue

* Фикс бага с бесконечным скелетоном AsideMenu при нажатии на Показать/Скрыть завершенные задачи

* Не перебрасывается последняя карточка из неразобранного

* Отображается неразобранное при драг-н-дропе карточек

* Рефакторинг

Убрал консоль

* Рефакторинг

Убрал фото если нет, имя пользователя если нет такого вопросами

* Не верно отрабатывает выбор карточки

Бывает не кликается (из-за того что включается драг-н-дроп или жмем в область вокруг меню)

* устанвил delay на 80 мс

* Фикс бага с неотображением вкладки сегодня после перезагрузки на ней (при рефакторе убрал ключ 'value' который был необходим)

* убрал лишнюю проверку в reglaments questions websync

* Добавил необхоидмые value ключи

* Убрал обращение к NAVIGATOR_REQUEST в методе PATCH_SETTING

* логика для websync reglaemnt answers в отдельном файле

* Убрал несуществующую функцию

* ДОбавил фильтр "Нет ответственного"

* добавил мутацию обновления вопроса

* привязал логику добавления, удаления, обновления вопросов и ответов в websync

* пофиксил баг, когда нельзя было проставить редакторов в только что созданном регламенте

* пофиксил баг, когда не удалялся регламент из навигатора

* Поправлен драг-н-дроп карточек

Запрещаем драг-н-дроп если отфильтровали (иначе не те карточки кидает)

* исправил ошибку createReglamentAnswer is not a function

* Исправлено не обновляется регламент по кнопке сохранить

* Билд 28 июля (#260)

* список сотрудников в попменю редакторов в регламентах

* добавление сотруддника в editors

* Заменил lg property на xl, чтобы небыло расхождений по верстке на разных экранах (т.к отказались от промежуточного lg экрана)

* добавлены лимиты в регламенты

* Закрытие левого AsideMenu при клике на какой-либо пункт меню

* не отображать вопрос (если нет правильного ответа)/кнопку (если в регламенте нет правильных ответов

* владелец лицензии может удалить любой регламент

* Убрал из очереди задачи, за которыми не следим

* плавный скролл переноса карточек

добавил чувствительность скролла и теперь присутсвует скролл при подносе карточки вверх таблицы и вниз

* поправил return

* корректная проверка на владельца лицензии

* давать доступ на редактирование регламента сотрудникам

* fix conflicts

* В свойствах сотрудника отображать всё регламенты

* пустое имя в прошедших регламент

теперь отображение почты если нет имени

* Фикс: при нажатии на новую созданную субтаску без имени - имя теперь можно изменить

* отображение поля редакторы и фикс скроллов в попменю

* логика отображения выбранных сотрудников в попменю редакторов регламентов

* Добавил консоль на выбранную задачу

Убрал лишние консольки

* правка галочки в попменю

* скролл в конец заметки

* Кнопка "Передать инспектору" в свойствах задачи

* удаление комментариев

неиспользуемая переменная, комментирование строки для пробела

* Рефакторинг

Теперь без запроса получение пройденных регламентов

* автор регламента не может добавить себя в редакторы

* замени массив editors на поле editors в регламентах

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* ошибка создания регламента

* рабочее рендактирование рпегламента

* переделал логику доступа редакторов к редактированию регламента

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты(переделал)

* фикс ошибки unknown mutation type при выходе из аккаунта

* Update NavBarButtonsRight.vue

Поправил краш

* Фикс бага с пустыми и ломаными документами в чате задачи. Ссылка теперь приходит корректно и файл скачивается полностью

* редактор не может добавлять редакторов

* убрал ошибку undefined reading greedpath при входе в аккаунт

* отображение почты если указано имя

в карточках в колонках, в ответственных, в очереди

* перенос логики в store

* фикс селекта ответов

* реактивная очистка сотрудников и изменение условий проверки

* Update BoardCard.vue

* фикс svg'шки почты на странице логина(ошибку)

* исправление ошибки svg стрелочки на странице логина

* исправление стрелочки назад

* рефакторинг InspectorNotification.vue

* удаление закомментированного кода

удаление кода, который висит закомментированным месяцами и не используется

* рефакторинг moviepreloader.vue

* Рефактор FileMessage.vue в options API

* websync создание регламентов

* закомментировал изменения по вебсинку

* рабочий websync регламентов

* Update ModalBox.vue

Добавил установить еще две кнопки accept - активная кнопка, decline - пассивная (по цвету различные) и эмитят соответствующие события по нажатию

* Update navigator.js

Инвайты теперь сервер присылает по другому - этот кода не рабочий - убран

* websync регламентов

* Update BoardCard.vue

* Update CardResponsibleUser.vue

* добавил getter в navbar.js 'lastNavStackElement'

* Home.vue рефактор

* логика для websync reglament questions в отдельном файле

* Исправлено сообщение от инспектора

Не отображалось имя заказчика в сообщении о том что просрочена задача

* Update CardResponsibleUser.vue

* Фикс бага с бесконечным скелетоном AsideMenu при нажатии на Показать/Скрыть завершенные задачи

* Не перебрасывается последняя карточка из неразобранного

* Отображается неразобранное при драг-н-дропе карточек

* Рефакторинг

Убрал консоль

* Рефакторинг

Убрал фото если нет, имя пользователя если нет такого вопросами

* Не верно отрабатывает выбор карточки

Бывает не кликается (из-за того что включается драг-н-дроп или жмем в область вокруг меню)

* устанвил delay на 80 мс

* Фикс бага с неотображением вкладки сегодня после перезагрузки на ней (при рефакторе убрал ключ 'value' который был необходим)

* убрал лишнюю проверку в reglaments questions websync

* Добавил необхоидмые value ключи

* Убрал обращение к NAVIGATOR_REQUEST в методе PATCH_SETTING

* логика для websync reglaemnt answers в отдельном файле

* Убрал несуществующую функцию

* ДОбавил фильтр "Нет ответственного"

* добавил мутацию обновления вопроса

* привязал логику добавления, удаления, обновления вопросов и ответов в websync

* пофиксил баг, когда нельзя было проставить редакторов в только что созданном регламенте

* пофиксил баг, когда не удалялся регламент из навигатора

* Поправлен драг-н-дроп карточек

Запрещаем драг-н-дроп если отфильтровали (иначе не те карточки кидает)

* исправил ошибку createReglamentAnswer is not a function

* Исправлено не обновляется регламент по кнопке сохранить

Co-authored-by: kakeoff <jasonsuper04@gmail.com>
Co-authored-by: Samarkin danya0 Danil <samarkin.danil@yandex.ru>
Co-authored-by: Bukharin Maxim <jojojopa@icloud.com>
Co-authored-by: danya0 <50441905+danya0@users.noreply.github.com>
Co-authored-by: yzk-jssc <egonik1337@gmail.com>
Co-authored-by: Panteleev Egor <101832333+kakeoff@users.noreply.github.com>
Co-authored-by: Maslov Dmitry <63534992+devmaslove@users.noreply.github.com>

* пофиксил баг с шивронами, когда драгаешь задачу, иногда шиврон не появлялся

* добавил возможность создавать редактировать и проходить регламенты при триале

* Вывод отдела в свойствах регламента

* Установка отдела у регламента

* Поменял формулировку общих регламентов

* теперь при создании вопроса, сразу же создается пустой ответ и на сервере

* Фикс бага: не обновлялся раздел 'Поручения' при удалении последней задачи в 'Поручено мне'

* Разбивка регламентов по отделам

* Только доступные регламенты

Можно добавлять регламенты сразу в свой отдел, отображаются только общие регламенты и регламенты из своего отдела, админы могу посмотреть все регламенты

* Убрал возможность установить не свой отдел у регламента

* рефакторинг(перенос всех popmenu из modals в common

* save changes

* В свойствах сотрудника регламенты отдела

* изменение визуала в очереди

* Убрал задержку при драг-н-дропе

* Выделять карточку при "быстром" дропе

* сделал правнее анимацию драга карточек, поставил больше scroll sensitivity, и добавил fall-backtolerance=1

* Билд 29 Июля (#274)

* список сотрудников в попменю редакторов в регламентах

* добавление сотруддника в editors

* Заменил lg property на xl, чтобы небыло расхождений по верстке на разных экранах (т.к отказались от промежуточного lg экрана)

* добавлены лимиты в регламенты

* Закрытие левого AsideMenu при клике на какой-либо пункт меню

* не отображать вопрос (если нет правильного ответа)/кнопку (если в регламенте нет правильных ответов

* владелец лицензии может удалить любой регламент

* Убрал из очереди задачи, за которыми не следим

* плавный скролл переноса карточек

добавил чувствительность скролла и теперь присутсвует скролл при подносе карточки вверх таблицы и вниз

* поправил return

* корректная проверка на владельца лицензии

* давать доступ на редактирование регламента сотрудникам

* fix conflicts

* В свойствах сотрудника отображать всё регламенты

* пустое имя в прошедших регламент

теперь отображение почты если нет имени

* Фикс: при нажатии на новую созданную субтаску без имени - имя теперь можно изменить

* отображение поля редакторы и фикс скроллов в попменю

* логика отображения выбранных сотрудников в попменю редакторов регламентов

* Добавил консоль на выбранную задачу

Убрал лишние консольки

* правка галочки в попменю

* скролл в конец заметки

* Кнопка "Передать инспектору" в свойствах задачи

* удаление комментариев

неиспользуемая переменная, комментирование строки для пробела

* Рефакторинг

Теперь без запроса получение пройденных регламентов

* автор регламента не может добавить себя в редакторы

* замени массив editors на поле editors в регламентах

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* ошибка создания регламента

* рабочее рендактирование рпегламента

* переделал логику доступа редакторов к редактированию регламента

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты(переделал)

* фикс ошибки unknown mutation type при выходе из аккаунта

* Update NavBarButtonsRight.vue

Поправил краш

* Фикс бага с пустыми и ломаными документами в чате задачи. Ссылка теперь приходит корректно и файл скачивается полностью

* редактор не может добавлять редакторов

* убрал ошибку undefined reading greedpath при входе в аккаунт

* отображение почты если указано имя

в карточках в колонках, в ответственных, в очереди

* перенос логики в store

* фикс селекта ответов

* реактивная очистка сотрудников и изменение условий проверки

* Update BoardCard.vue

* фикс svg'шки почты на странице логина(ошибку)

* исправление ошибки svg стрелочки на странице логина

* исправление стрелочки назад

* рефакторинг InspectorNotification.vue

* удаление закомментированного кода

удаление кода, который висит закомментированным месяцами и не используется

* рефакторинг moviepreloader.vue

* Рефактор FileMessage.vue в options API

* websync создание регламентов

* закомментировал изменения по вебсинку

* рабочий websync регламентов

* Update ModalBox.vue

Добавил установить еще две кнопки accept - активная кнопка, decline - пассивная (по цвету различные) и эмитят соответствующие события по нажатию

* Update navigator.js

Инвайты теперь сервер присылает по другому - этот кода не рабочий - убран

* websync регламентов

* Update BoardCard.vue

* Update CardResponsibleUser.vue

* добавил getter в navbar.js 'lastNavStackElement'

* Home.vue рефактор

* логика для websync reglament questions в отдельном файле

* Исправлено сообщение от инспектора

Не отображалось имя заказчика в сообщении о том что просрочена задача

* Update CardResponsibleUser.vue

* Фикс бага с бесконечным скелетоном AsideMenu при нажатии на Показать/Скрыть завершенные задачи

* Не перебрасывается последняя карточка из неразобранного

* Отображается неразобранное при драг-н-дропе карточек

* Рефакторинг

Убрал консоль

* Рефакторинг

Убрал фото если нет, имя пользователя если нет такого вопросами

* Не верно отрабатывает выбор карточки

Бывает не кликается (из-за того что включается драг-н-дроп или жмем в область вокруг меню)

* устанвил delay на 80 мс

* Фикс бага с неотображением вкладки сегодня после перезагрузки на ней (при рефакторе убрал ключ 'value' который был необходим)

* убрал лишнюю проверку в reglaments questions websync

* Добавил необхоидмые value ключи

* Убрал обращение к NAVIGATOR_REQUEST в методе PATCH_SETTING

* логика для websync reglaemnt answers в отдельном файле

* Убрал несуществующую функцию

* ДОбавил фильтр "Нет ответственного"

* добавил мутацию обновления вопроса

* привязал логику добавления, удаления, обновления вопросов и ответов в websync

* пофиксил баг, когда нельзя было проставить редакторов в только что созданном регламенте

* пофиксил баг, когда не удалялся регламент из навигатора

* Поправлен драг-н-дроп карточек

Запрещаем драг-н-дроп если отфильтровали (иначе не те карточки кидает)

* исправил ошибку createReglamentAnswer is not a function

* Исправлено не обновляется регламент по кнопке сохранить

* пофиксил баг с шивронами, когда драгаешь задачу, иногда шиврон не появлялся

* добавил возможность создавать редактировать и проходить регламенты при триале

* Вывод отдела в свойствах регламента

* Установка отдела у регламента

* Поменял формулировку общих регламентов

* теперь при создании вопроса, сразу же создается пустой ответ и на сервере

* Разбивка регламентов по отделам

* Только доступные регламенты

Можно добавлять регламенты сразу в свой отдел, отображаются только общие регламенты и регламенты из своего отдела, админы могу посмотреть все регламенты

* Убрал возможность установить не свой отдел у регламента

* рефакторинг(перенос всех popmenu из modals в common

* save changes

* В свойствах сотрудника регламенты отдела

* изменение визуала в очереди

* Убрал задержку при драг-н-дропе

* Выделять карточку при "быстром" дропе

* сделал правнее анимацию драга карточек, поставил больше scroll sensitivity, и добавил fall-backtolerance=1

Co-authored-by: kakeoff <jasonsuper04@gmail.com>
Co-authored-by: Samarkin danya0 Danil <samarkin.danil@yandex.ru>
Co-authored-by: Bukharin Maxim <jojojopa@icloud.com>
Co-authored-by: danya0 <50441905+danya0@users.noreply.github.com>
Co-authored-by: yzk-jssc <egonik1337@gmail.com>
Co-authored-by: Panteleev Egor <101832333+kakeoff@users.noreply.github.com>
Co-authored-by: Maslov Dmitry <63534992+devmaslove@users.noreply.github.com>

* websynk колонок в досках

* яндекс метрика на очереди

* Билд 1 Августа (#282)

* список сотрудников в попменю редакторов в регламентах

* добавление сотруддника в editors

* Заменил lg property на xl, чтобы небыло расхождений по верстке на разных экранах (т.к отказались от промежуточного lg экрана)

* добавлены лимиты в регламенты

* Закрытие левого AsideMenu при клике на какой-либо пункт меню

* не отображать вопрос (если нет правильного ответа)/кнопку (если в регламенте нет правильных ответов

* владелец лицензии может удалить любой регламент

* Убрал из очереди задачи, за которыми не следим

* плавный скролл переноса карточек

добавил чувствительность скролла и теперь присутсвует скролл при подносе карточки вверх таблицы и вниз

* поправил return

* корректная проверка на владельца лицензии

* давать доступ на редактирование регламента сотрудникам

* fix conflicts

* В свойствах сотрудника отображать всё регламенты

* пустое имя в прошедших регламент

теперь отображение почты если нет имени

* Фикс: при нажатии на новую созданную субтаску без имени - имя теперь можно изменить

* отображение поля редакторы и фикс скроллов в попменю

* логика отображения выбранных сотрудников в попменю редакторов регламентов

* Добавил консоль на выбранную задачу

Убрал лишние консольки

* правка галочки в попменю

* скролл в конец заметки

* Кнопка "Передать инспектору" в свойствах задачи

* удаление комментариев

неиспользуемая переменная, комментирование строки для пробела

* Рефакторинг

Теперь без запроса получение пройденных регламентов

* автор регламента не может добавить себя в редакторы

* замени массив editors на поле editors в регламентах

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* ошибка создания регламента

* рабочее рендактирование рпегламента

* переделал логику доступа редакторов к редактированию регламента

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты(переделал)

* фикс ошибки unknown mutation type при выходе из аккаунта

* Update NavBarButtonsRight.vue

Поправил краш

* Фикс бага с пустыми и ломаными документами в чате задачи. Ссылка теперь приходит корректно и файл скачивается полностью

* редактор не может добавлять редакторов

* убрал ошибку undefined reading greedpath при входе в аккаунт

* отображение почты если указано имя

в карточках в колонках, в ответственных, в очереди

* перенос логики в store

* фикс селекта ответов

* реактивная очистка сотрудников и изменение условий проверки

* Update BoardCard.vue

* фикс svg'шки почты на странице логина(ошибку)

* исправление ошибки svg стрелочки на странице логина

* исправление стрелочки назад

* рефакторинг InspectorNotification.vue

* удаление закомментированного кода

удаление кода, который висит закомментированным месяцами и не используется

* рефакторинг moviepreloader.vue

* Рефактор FileMessage.vue в options API

* websync создание регламентов

* закомментировал изменения по вебсинку

* рабочий websync регламентов

* Update ModalBox.vue

Добавил установить еще две кнопки accept - активная кнопка, decline - пассивная (по цвету различные) и эмитят соответствующие события по нажатию

* Update navigator.js

Инвайты теперь сервер присылает по другому - этот кода не рабочий - убран

* websync регламентов

* Update BoardCard.vue

* Update CardResponsibleUser.vue

* добавил getter в navbar.js 'lastNavStackElement'

* Home.vue рефактор

* логика для websync reglament questions в отдельном файле

* Исправлено сообщение от инспектора

Не отображалось имя заказчика в сообщении о том что просрочена задача

* Update CardResponsibleUser.vue

* Фикс бага с бесконечным скелетоном AsideMenu при нажатии на Показать/Скрыть завершенные задачи

* Не перебрасывается последняя карточка из неразобранного

* Отображается неразобранное при драг-н-дропе карточек

* Рефакторинг

Убрал консоль

* Рефакторинг

Убрал фото если нет, имя пользователя если нет такого вопросами

* Не верно отрабатывает выбор карточки

Бывает не кликается (из-за того что включается драг-н-дроп или жмем в область вокруг меню)

* устанвил delay на 80 мс

* Фикс бага с неотображением вкладки сегодня после перезагрузки на ней (при рефакторе убрал ключ 'value' который был необходим)

* убрал лишнюю проверку в reglaments questions websync

* Добавил необхоидмые value ключи

* Убрал обращение к NAVIGATOR_REQUEST в методе PATCH_SETTING

* логика для websync reglaemnt answers в отдельном файле

* Убрал несуществующую функцию

* ДОбавил фильтр "Нет ответственного"

* добавил мутацию обновления вопроса

* привязал логику добавления, удаления, обновления вопросов и ответов в websync

* пофиксил баг, когда нельзя было проставить редакторов в только что созданном регламенте

* пофиксил баг, когда не удалялся регламент из навигатора

* Поправлен драг-н-дроп карточек

Запрещаем драг-н-дроп если отфильтровали (иначе не те карточки кидает)

* исправил ошибку createReglamentAnswer is not a function

* Исправлено не обновляется регламент по кнопке сохранить

* пофиксил баг с шивронами, когда драгаешь задачу, иногда шиврон не появлялся

* добавил возможность создавать редактировать и проходить регламенты при триале

* Вывод отдела в свойствах регламента

* Установка отдела у регламента

* Поменял формулировку общих регламентов

* теперь при создании вопроса, сразу же создается пустой ответ и на сервере

* Фикс бага: не обновлялся раздел 'Поручения' при удалении последней задачи в 'Поручено мне'

* Разбивка регламентов по отделам

* Только доступные регламенты

Можно добавлять регламенты сразу в свой отдел, отображаются только общие регламенты и регламенты из своего отдела, админы могу посмотреть все регламенты

* Убрал возможность установить не свой отдел у регламента

* рефакторинг(перенос всех popmenu из modals в common

* save changes

* В свойствах сотрудника регламенты отдела

* изменение визуала в очереди

* Убрал задержку при драг-н-дропе

* Выделять карточку при "быстром" дропе

* сделал правнее анимацию драга карточек, поставил больше scroll sensitivity, и добавил fall-backtolerance=1

* websynk колонок в досках

* яндекс метрика на очереди

Co-authored-by: kakeoff <jasonsuper04@gmail.com>
Co-authored-by: Samarkin danya0 Danil <samarkin.danil@yandex.ru>
Co-authored-by: Bukharin Maxim <jojojopa@icloud.com>
Co-authored-by: danya0 <50441905+danya0@users.noreply.github.com>
Co-authored-by: yzk-jssc <egonik1337@gmail.com>
Co-authored-by: Panteleev Egor <101832333+kakeoff@users.noreply.github.com>
Co-authored-by: Maslov Dmitry <63534992+devmaslove@users.noreply.github.com>

* Убарл горизонтальный скролл основного контента при выдвинутом AsideMenu на lg экранах

* Рефактор store/boards. Вписал новые мутации в экшны

Co-authored-by: Samarkin danya0 Danil <samarkin.danil@yandex.ru>
Co-authored-by: Maslov Dmitry <63534992+devmaslove@users.noreply.github.com>
Co-authored-by: Bukharin Maxim <jojojopa@icloud.com>
Co-authored-by: Panteleev Egor <101832333+kakeoff@users.noreply.github.com>
Co-authored-by: danya0 <50441905+danya0@users.noreply.github.com>
Co-authored-by: yzk-jssc <egonik1337@gmail.com>
Co-authored-by: kakeoff <jasonsuper04@gmail.com>

Co-authored-by: Samarkin danya0 Danil <samarkin.danil@yandex.ru>
Co-authored-by: Maslov Dmitry <63534992+devmaslove@users.noreply.github.com>
Co-authored-by: Bukharin Maxim <jojojopa@icloud.com>
Co-authored-by: Panteleev Egor <101832333+kakeoff@users.noreply.github.com>
Co-authored-by: danya0 <50441905+danya0@users.noreply.github.com>
Co-authored-by: yzk-jssc <egonik1337@gmail.com>
Co-authored-by: kakeoff <jasonsuper04@gmail.com>

* Фикс выделения даты при нажатие сегодня

* Question.name теперь передается как текст, а не как html (избегаем бага с возможностью писать любой html в текст вопроса регламента)

* изменил contenteditable в очереди на input

* скрывать элемент заметки если она пустая и мы с ней ничего не можем сделать

* При изменении названия доски оно теперь также изменяется в navbar'e

* отображение подзадач в очереди/модалка при изменении статуса задачи

* проверка изменения статуса задачи по кнопкам в очереди/измененеие текста

* отображение сотрудников прошедших регламент по нажатию на кнопку

* изменения по отображению сотрудников

* метрика на инспекторе

* Билд 3 Августа (#311)

* список сотрудников в попменю редакторов в регламентах

* добавление сотруддника в editors

* Заменил lg property на xl, чтобы небыло расхождений по верстке на разных экранах (т.к отказались от промежуточного lg экрана)

* добавлены лимиты в регламенты

* Закрытие левого AsideMenu при клике на какой-либо пункт меню

* не отображать вопрос (если нет правильного ответа)/кнопку (если в регламенте нет правильных ответов

* владелец лицензии может удалить любой регламент

* Убрал из очереди задачи, за которыми не следим

* плавный скролл переноса карточек

добавил чувствительность скролла и теперь присутсвует скролл при подносе карточки вверх таблицы и вниз

* поправил return

* корректная проверка на владельца лицензии

* давать доступ на редактирование регламента сотрудникам

* fix conflicts

* В свойствах сотрудника отображать всё регламенты

* пустое имя в прошедших регламент

теперь отображение почты если нет имени

* Фикс: при нажатии на новую созданную субтаску без имени - имя теперь можно изменить

* отображение поля редакторы и фикс скроллов в попменю

* логика отображения выбранных сотрудников в попменю редакторов регламентов

* Добавил консоль на выбранную задачу

Убрал лишние консольки

* правка галочки в попменю

* скролл в конец заметки

* Кнопка "Передать инспектору" в свойствах задачи

* удаление комментариев

неиспользуемая переменная, комментирование строки для пробела

* Рефакторинг

Теперь без запроса получение пройденных регламентов

* автор регламента не может добавить себя в редакторы

* замени массив editors на поле editors в регламентах

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* доступ к регламенту пользователю

* ошибка создания регламента

* рабочее рендактирование рпегламента

* переделал логику доступа редакторов к редактированию регламента

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты

* админы и суперадмины могут редактировать все регламенты(переделал)

* фикс ошибки unknown mutation type при выходе из аккаунта

* Update NavBarButtonsRight.vue

Поправил краш

* Фикс бага с пустыми и ломаными документами в чате задачи. Ссылка теперь приходит корректно и файл скачивается полностью

* редактор не может добавлять редакторов

* убрал ошибку undefined reading greedpath при входе в аккаунт

* отображение почты если указано имя

в карточках в колонках, в ответственных, в очереди

* перенос логики в store

* фикс селекта ответов

* реактивная очистка сотрудников и изменение условий проверки

* Update BoardCard.vue

* фикс svg'шки почты на странице логина(ошибку)

* исправление ошибки svg стрелочки на странице логина

* исправление стрелочки назад

* рефакторинг InspectorNotification.vue

* удаление закомментированного кода

удаление кода, который висит закомментированным месяцами и не используется

* рефакторинг moviepreloader.vue

* Рефактор FileMessage.vue в options API

* websync создание регламентов

* закомментировал изменения по вебсинку

* рабочий websync регламентов

* Update ModalBox.vue

Добавил установить еще две кнопки accept - активная кнопка, decline - пассивная (по цвету различные) и эмитят соответствующие события по нажатию

* Update navigator.js

Инвайты теперь сервер присылает по другому - этот кода не рабочий - убран

* websync регламентов

* Update BoardCard.vue

* Update CardResponsibleUser.vue

* добавил getter в navbar.js 'lastNavStackElement'

* Home.vue рефактор

* логика для websync reglament questions в отдельном файле

* Исправлено сообщение от инспектора

Не отображалось имя заказчика в сообщении о том что просрочена задача

* Update CardResponsibleUser.vue

* Фикс бага с бесконечным скелетоном AsideMenu при нажатии на Показать/Скрыть завершенные задачи

* Не перебрасывается последняя карточка из неразобранного

* Отображается неразобранное при драг-н-дропе карточек

* Рефакторинг

Убрал консоль

* Рефакторинг

Убрал фото если нет, имя пользователя если нет такого вопросами

* Не верно отрабатывает выбор карточки

Бывает не кликается (из-за того что включается драг-н-дроп или жмем в область вокруг меню)

* устанвил delay на 80 мс

* Фикс бага с неотображением вкладки сегодня после перезагрузки на ней (при рефакторе убрал ключ 'value' который был необходим)

* убрал лишнюю проверку в reglaments questions websync

* Добавил необхоидмые value ключи

* Убрал обращение к NAVIGATOR_REQUEST в методе PATCH_SETTING

* логика для websync reglaemnt answers в отдельном файле

* Убрал несуществующую функцию

* ДОбавил фильтр "Нет ответственного"

* добавил мутацию обновления вопроса

* привязал логику добавления, удаления, обновления вопросов и ответов в websync

* пофиксил баг, когда нельзя было проставить редакторов в только что созданном регламенте

* пофиксил баг, когда не удалялся регламент из навигатора

* Поправлен драг-н-дроп карточек

Запрещаем драг-н-дроп если отфильтровали (иначе не те карточки кидает)

* исправил ошибку createReglamentAnswer is not a function

* Исправлено не обновляется регламент по кнопке сохранить

* пофиксил баг с шивронами, когда драгаешь задачу, иногда шиврон не появлялся

* добавил возможность создавать редактировать и проходить регламенты при триале

* Вывод отдела в свойствах регламента

* Установка отдела у регламента

* Поменял формулировку общих регламентов

* теперь при создании вопроса, сразу же создается пустой ответ и на сервере

* Фикс бага: не обновлялся раздел 'Поручения' при удалении последней задачи в 'Поручено мне'

* Разбивка регламентов по отделам

* Только доступные регламенты

Можно добавлять регламенты сразу в свой отдел, отображаются только общие регламенты и регламенты из своего отдела, админы могу посмотреть все регламенты

* Убрал возможность установить не свой отдел у регламента

* рефакторинг(перенос всех popmenu из modals в common

* save changes

* В свойствах сотрудника регламенты отдела

* изменение визуала в очереди

* Убрал задержку при драг-н-дропе

* Выделять карточку при "быстром" дропе

* сделал правнее анимацию драга карточек, поставил больше scroll sensitivity, и добавил fall-backtolerance=1

* websynk колонок в досках

* яндекс метрика на очереди

* Убарл горизонтальный скролл основного контента при выдвинутом AsideMenu на lg экранах

* Рефактор store/boards. Вписал новые мутации в экшны

* Релиз "Регламенты" (#291) (#292)

* Фикс: больше не пропадает подзадача при клике на неё, только при потере фокуса

* Update Reglaments.vue

Добавлено разделение на свои и чужие регламенты

* баг с исчезновением отступов при закрытии свойств на esc

* reglament debug

* удаление иконки

удаление иконки скрытия для бурегера (не нужной) на средних экранах

* На пройденных регламентах галочка

* Update Reglaments.vue

Убрал консоль

* добавил мутацию update reglament и привязал ее к кнопке пройти тест

* правки по дизайну в регламентах

* правки по дизайну в регламентах

* прохождение регламента начинается сверху страницы

перемещение скролла вверх страницы при старте регламента

* правки по вопросам и ответам в регламентах

* запрос на удаление ответов пользователей/настройка в режиме редактировании

* теперь после обновления страницы лт не ломается

* Теперь подзадачи пропадают, в случае если мы отказываемся от доступа к ней (до этого удалялись только после перезагрузки)

* добавил отображение пройденных регламентов в свойствах сотрудника

* рефакторинг 2 компонентов( комментарий)

удаление закоменнтированного кода и поправление кода с помощью eslint

* кликабельная ссылка в описании

* Регламенты редактирование и отображение

Регламент - отображение и редактирование, редактирование только при создании + рефакторинг

* изначальное значение для бюджета

в бюджете, если нет прошлого значения пустая строка, если есть показывает указанное в бюджете

* Цвета сразу добавляются в 'color', чтобы плашка красилась без перезагрузки страницы

* рефакторинг employee.vue

* поправил отображение неправильных ответов

* удаление неиспользуемого закоменнтированного кода

* логика для селекта одного ответа

* добавил отображение инспектруемых задач в списке

* рефакторинг ControlIcon.vue

* Билд 22 Июля (#226)

* Update README.md

Коммиты пишем русским языком

* Update CardName.vue

Не верно отображается заголовок у карточки

* Кнопка пройти тесты подгружается быстрее/при создании регламента сразу переходим в режим редактирования

* убрана функция покинуть регламент

* фикс бага если нет тарифа альфа, то в настройках аккаунта были ограничены все разделы, хотя должен быть ограничен только раздел кармы

* Update AsideMenu.vue

Не загружается приложение при первом входе

* вернул изменения по смене названия задачи

* Показывается количество правильных ответов в вопросе

* Пропадает поле название у карточки если стереть всё в хроме

* вынес логику инициализации navStack в отдельную функцию в Home.vue

* Update README.md

Дополнил про коммиты

* Update DoitnowTask.vue

Рефакторинг

* изменения в компонентах регламентов и добавление иконки регламентам

* небольшой рефакторинг по DRY в Home.vue

* Отображение вопросов, на которые мы дали неверный ответ

* При создании вопроса в регламенте нужно сразу создавать вместе с ним один ответ

* фикс багов (#214)

* фикс бага если нет тарифа альфа, то в настройках аккаунта были ограничены все разделы, хотя должен быть ограничен только раздел кармы

* вернул изменения по смене названия задачи

* изменения в компонентах регламентов и добавление иконки регламентам

* Task day fix (#217)

* набросок(без редиректа на регламент)

* реализация перехода по ссылке

* исправление конфликтов

Co-authored-by: Dmitry <gashilovdmitry@yandex.ru>

* свойства перенесены на лицевую сторону регламентов

* свойства регламентов перенесены на лицевую часть регламента

* Update TaskProperties.vue

Фикс: Стирается вводимое сейчас сообщение при обновлении задачи через вебсинк (сделал проверку смены задачи по uid)

* добавил скелетон для меню левого меню навигации

* убрал script из компонента скелетона

* добавил поле user_uid к запросу регламентов (для флага is_passed у самого регламента при получении списка)

* Баг фиксы (#218)

* Добавил в websynk updateTask удаление задачи в случае если удалили дату; и перенос задачи на другую дату

* Добавил в websynk updateTask удаление задачи в случае если удалили дату; и перенос задачи на другую дату #2

* User-Frendly сообщение, при нажатии на: 'Цвет', 'Проект', 'Метки' - в случае если они пустые

* Удалил add dot из вебсинка

* Правки по визуалу в регламентах. Убраны дубликаты сотрудников, изменены подложки у сообщений

* фикс по удалению регламента

* changes

* фикс кнопка редактировать видна при прохождении теста, кнопка пройти тест видна после прохождения теста

* fixing bugs (#219)

* фикс бага если нет тарифа альфа, то в настройках аккаунта были ограничены все разделы, хотя должен быть ограничен только раздел кармы

* вернул изменения по смене названия задачи

* изменения в компонентах регламентов и добавление иконки регламентам

* добавил скелетон для меню левого меню навигации

* убрал script из компонента скелетона

* фикс кнопка редактировать видна при прохождении теста, кнопка пройти тест видна после прохождения теста

* Update FileMessage.vue

Исправлено дублирование картинок

* Добавил scoped к стилям, больше нет багов с subtask и чек-листом (#220)

* Update FileMessage.vue

Вставил ограничение на 10 попыток скачать файл

* Баг с шириной плашек

Не верно отображаются плашки по ширине - уходят за экран если их отобразить списком

* Закрытие PropertiesRightAside, если оно открыто - при переходе на избранную вкладку

* левая меню на средних экранах

теперь левая менюшка "катается" так же как на мобилках

* Фикс: больше не пропадает подзадача при клике на неё, только при потере фокуса

* Update Reglaments.vue

Добавлено разделение на свои и чужие регламенты

* баг с исчезновением отступов при закрытии свойств на esc

* reglament debug

* удаление иконки

удаление иконки скрытия для бурегера (не нужной) на средних экранах

* На пройденных регламентах галочка

* Update Reglaments.vue

Убрал консоль

* добавил мутацию update reglament и привязал ее к кнопке пройти тест

* правки по дизайну в регламентах

* правки по дизайну в регламентах

* прохождение регламента начинается сверху страницы

перемещение скролла вверх страницы при старте регламента

* правки по вопросам и ответам в регламентах

* запрос на удаление ответов пользователей/настройка в режиме редактировании

* теперь после обновления страницы лт не ломается

* Теперь подзадачи пропадают, в случае если мы отказываемся от доступа к ней (до этого удалялись только после перезагрузки)

* добавил отображение пройденных регламентов в свойствах сотрудника

* рефакторинг 2 компонентов( комментарий)

удаление закоменнтированного кода и поправление кода с помощью eslint

* кликабельная ссылка в описании

* Регламенты редактирование и отображение

Регламент - отображение и редактирование, редактирование только при создании + рефакторинг

* изначальное значение для бюджета

в бюджете, если нет прошлого значения пустая строка, если есть показывает указанное в бюджете

* Цвета сразу добавляются в 'color', чтобы плашка красилась без перезагрузки страницы

* рефакторинг employee.vue

* поправил отображение неправильных ответов

* удаление неиспользуемого закоменнтированного кода

* логика для селекта одного ответа

* добавил отображение инспектруемых задач в списке

* рефакторинг ControlIcon.vue

Co-authored-by: Maslov Dmitry <63534992+devmaslove@users.noreply.github.com>
Co-authored-by: Bukharin Maxim <jojojopa@icloud.com>
Co-authored-by: kakeoff <jasonsuper04@gmail.com>
Co-authored-by: Panteleev Egor <101832333+kakeoff@users.noreply.github.com>
Co-authored-by: Egor <egonik1337@gmail.com>
Co-authored-by: danya0 <50441905+danya0@users.noreply.github.com>
Co-authored-by: Samarkin danya0 Danil <samarkin.danil@yandex.ru>

* фикс ошибок, после фикса конфликтов

* убарл коммент

* Выправил коммиты

* запрет на перенос строки в вопросах регламента

* логика с отображение неправильных вопросов/выравнивание текста

* переделана логика для отображения неправильных вопросов

* поправил ошибку с иконкой

* поправил размер иконки

* Отображене избранных вкладок под главным списком меню

* Убарл неиспользуемые передаваемые пропсы и эмиты в AsideMenuList

* добавил отправку инфо организации при инициализации websocket inspector

* Update main.js

Поправил краш при анализе ошибки от сервера

* добавил отправку токена при инициализации websocket inspector

* загрузка регламентов отложена

* вернул старую логику

* фикс некорректное добавление задачи с меткой

* логика для показа неправильных вопросов

* Update Home.vue

Поправил загрузку навигатора - показываем что грузимся до запроса регламентов и запускаем загрузку навигатора не зависимо от того удалось ли загрузить регламенты

* развыделять ответы, после того как тест был пройден

* Update NavBarButtonsReglament.vue

Поправил краш

* добавит типы для websync регламентов

* добавление редакторов в регламенты(не доделано)

* убрал консол лог

* добавил логи…