### PR TITLE
Фикс дергания меню при изменении статуса задачи

### DIFF
--- a/src/components/TasksListNew.vue
+++ b/src/components/TasksListNew.vue
@@ -1147,20 +1147,25 @@ export default {
         if (!this.$store.state.navigator.navigator.settings.show_completed_tasks && [1, 5, 7, 8].includes(status)) {
           // получаем массив ключей и переворачиваем, чтобы получить текущий
           const tasksKeyArray = Object.keys(this?.storeTasks)
-          const nextTaskIndex = tasksKeyArray.reverse().indexOf(task.uid) + 1
+          const currentSelectedTaskIndex = tasksKeyArray.reverse().indexOf(task.uid)
+          const nextSelectedTaskIndex = tasksKeyArray[currentSelectedTaskIndex + 1] ? currentSelectedTaskIndex + 1 : currentSelectedTaskIndex - 1
 
           this.$store.dispatch(TASK.REMOVE_TASK, task.uid).then(() => {
+            this.$store.commit(TASK.REMOVE_TASK, task.uid)
+            this.$store.dispatch(TASK.DAYS_WITH_TASKS)
             // получаем юид и его дату
-            const nextTaskUid = tasksKeyArray[nextTaskIndex]
-            const nextTaskData = this.storeTasks[nextTaskUid]
+            const nextSelectedTaskUid = tasksKeyArray[nextSelectedTaskIndex]
+            const nextSelectedTaskData = this.storeTasks[nextSelectedTaskUid]
+
+            if (!nextSelectedTaskUid || !nextSelectedTaskData) {
+              this.$store.dispatch('asidePropertiesToggle', false)
+              return
+            }
             // фокусим следующий итем и открываем его свойства
-            document.getElementById(nextTaskUid || nextTaskUid - 1).focus({ preventScroll: false })
-            this.nodeSelected({ id: nextTaskData.id, info: nextTaskData.info })
-            this.lastSelectedTaskUid = nextTaskUid
+            document.getElementById(nextSelectedTaskUid || nextSelectedTaskUid - 1).focus({ preventScroll: false })
+            this.nodeSelected({ id: nextSelectedTaskData.id, info: nextSelectedTaskData.info })
+            this.lastSelectedTaskUid = nextSelectedTaskUid
           })
-          this.$store.commit(TASK.REMOVE_TASK, task.uid)
-          this.$store.dispatch('asidePropertiesToggle', false)
-          this.$store.dispatch(TASK.DAYS_WITH_TASKS)
         }
       })
     }


### PR DESCRIPTION
* Исправлена ошибка, когда при смене статуса задачи меню закрывалось, а потом сразу открывалось
* Теперь при изменении статуса последней задачи выбирается та задача, которая была до неё