### PR TITLE
Фикс драг-н-дропа подзадачи

### DIFF
--- a/src/components/TasksListNew.vue
+++ b/src/components/TasksListNew.vue
@@ -1115,6 +1115,10 @@ export default {
           parentUid = elem
         }
       }
+      this.storeTasks[node.dragged.node.id].parent = parentUid ?? '00000000-0000-0000-0000-000000000000'
+      this.storeTasks[node.dragged.node.id].info.uid_parent = parentUid ?? '00000000-0000-0000-0000-000000000000'
+      this.$store.state.tasks.selectedTask = this.storeTasks[node.dragged.node.id].info
+      debugger
       this.$store.dispatch(
         TASK.CHANGE_TASK_PARENT_AND_ORDER,
         {


### PR DESCRIPTION
Фикс ошибки, когда после драг-н-дропа подзадачи, у неё в свойствах не менялся родитель